### PR TITLE
Update symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     "source": "https://github.com/ErdmannFreunde/contao-grid-bundle"
   },
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "contao/core-bundle": "^5.0",
-    "symfony/config": "^5.0 || ^6.0",
-    "symfony/dependency-injection": "^5.0 || ^6.0",
-    "symfony/http-kernel": "^5.0 || ^6.0"
+    "symfony/config": "^6.4 || ^7.0",
+    "symfony/dependency-injection": "^6.4 || ^7.0",
+    "symfony/http-kernel": "^6.4 || ^7.0"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.7",


### PR DESCRIPTION
Compatiblity for Contao 5.6+ with Symfony 7 
This PR will close https://github.com/erdmannfreunde/contao-grid-bundle/issues/26